### PR TITLE
Update Reviews page to work with URL Queries

### DIFF
--- a/components/modal/EditReviewModal.tsx
+++ b/components/modal/EditReviewModal.tsx
@@ -2,11 +2,6 @@
 import { Review } from '@/util/interfaces/interfaces'
 import { Dispatch, Fragment, SetStateAction, useState } from 'react'
 import countries from '@/util/countries/countries.json'
-import provinces from '@/util/countries/canada/provinces.json'
-import regions from '@/util/countries/unitedKingdom/regions.json'
-import states from '@/util/countries/unitedStates/states.json'
-import territories from '@/util/countries/australia/territories.json'
-import counties from '@/util/countries/ireland/counties.json'
 import { country_codes } from '@/util/helpers/getCountryCodes'
 import {
 	Dialog,
@@ -17,6 +12,7 @@ import {
 import { useUser } from '@auth0/nextjs-auth0/client'
 import dayjs from 'dayjs'
 import { toast } from 'react-toastify'
+import { getStates } from '@/util/countries/combineStates'
 
 interface IProps {
 	selectedReview: Review | undefined
@@ -209,59 +205,11 @@ const EditReviewModal = ({
 												className='block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm'
 											>
 												<option>{province}</option>
-												{country === 'CA'
-													? provinces.map((province) => {
-															return (
-																<option
-																	key={province.short}
-																	value={province.name}
-																>
-																	{province.name}
-																</option>
-															)
-													  })
-													: country === 'GB'
-													? regions.map((region) => {
-															return (
-																<option key={region.short} value={region.name}>
-																	{region.name}
-																</option>
-															)
-													  })
-													: country === 'AU'
-													? territories.map((territory) => {
-															return (
-																<option
-																	key={territory.short}
-																	value={territory.name}
-																>
-																	{territory.name}
-																</option>
-															)
-													  })
-													: country === 'IE'
-													? counties.map((county) => {
-															return (
-																<option key={county.short} value={county.name}>
-																	{county.name}
-																</option>
-															)
-													  })
-													: country === 'NO'
-													? counties.map((county) => {
-															return (
-																<option key={county.short} value={county.name}>
-																	{county.name}
-																</option>
-															)
-													  })
-													: states.map((state) => {
-															return (
-																<option key={state.short} value={state.name}>
-																	{state.name}
-																</option>
-															)
-													  })}
+												{getStates(country).map((province) => (
+													<option key={province.value} value={province.value}>
+														{province.name}
+													</option>
+												))}
 											</select>
 										</div>
 									</div>

--- a/components/reviews/components/Hero.tsx
+++ b/components/reviews/components/Hero.tsx
@@ -1,30 +1,40 @@
 import ReviewHero from './ReviewHero'
 import LocationForm from './LocationForm'
 import { Options } from '@/util/interfaces/interfaces'
-import Spinner from '@/components/ui/Spinner'
-import Button from '@/components/ui/button'
 import Image from 'next/image'
-import { useTranslation } from 'next-i18next'
 import AdsComponent from '@/components/adsense/Adsense'
+import { useState } from 'react'
+import Button from '@/components/ui/button'
+import { useAppDispatch } from '@/redux/hooks'
+import { updateStateAndCountry } from '@/redux/query/querySlice'
+import { useTranslation } from 'next-i18next'
 
 interface IProps {
-	loading: boolean
 	countryFilter: Options | null
 	stateFilter: Options | null
-	dynamicStateOptions: Options[]
-	fetchDynamicFilterOptions: () => Promise<void>
-	handleSubmit: () => Promise<void>
 }
 
-const Hero = ({
-	loading,
-	countryFilter,
-	stateFilter,
-	dynamicStateOptions,
-	fetchDynamicFilterOptions,
-	handleSubmit,
-}: IProps) => {
+const Hero = ({ countryFilter, stateFilter }: IProps) => {
 	const { t } = useTranslation('reviews')
+	const [selectedCountry, setSelectedCountry] = useState<Options | null>(
+		countryFilter,
+	)
+	const [selectedState, setSelectedState] = useState<Options | null>(
+		stateFilter,
+	)
+
+	const dispatch = useAppDispatch()
+
+	const handleSubmit = () => {
+		if (selectedCountry && selectedState) {
+			dispatch(
+				updateStateAndCountry({
+					country: selectedCountry,
+					state: selectedState,
+				}),
+			)
+		}
+	}
 	return (
 		<div className='m-2 w-full  max-w-7xl'>
 			<div className='w-full'>
@@ -46,19 +56,17 @@ const Hero = ({
 							<ReviewHero />
 							<div className='w-full p-8 transition-all duration-300'>
 								<LocationForm
-									countryFilter={countryFilter}
-									stateFilter={stateFilter}
-									dynamicStateOptions={dynamicStateOptions}
-									fetchDynamicFilterOptions={fetchDynamicFilterOptions}
+									selectedCountry={selectedCountry}
+									selectedState={selectedState}
+									setSelectedCountry={setSelectedCountry}
+									setSelectedState={setSelectedState}
 								/>
 							</div>
 
 							<div className='flex w-full justify-center'>
-								{loading ? (
-									<Spinner />
-								) : !countryFilter || !stateFilter ? null : (
+								{!selectedCountry || !selectedState ? null : (
 									<Button
-										disabled={!countryFilter || !stateFilter}
+										disabled={!selectedCountry || !selectedState}
 										onClick={() => handleSubmit()}
 										size='large'
 									>

--- a/components/reviews/components/LocationForm.tsx
+++ b/components/reviews/components/LocationForm.tsx
@@ -1,48 +1,25 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Options } from '@/util/interfaces/interfaces'
 import { useTranslation } from 'next-i18next'
 import SelectList from '../ui/locationSelect-list'
 import ComboBox from '../ui/locationCombobox'
 import { countryOptions } from '@/util/helpers/getCountryCodes'
-import {
-	clearFilters,
-	updateCountry,
-	updateState,
-	updateActiveFilters,
-} from '@/redux/query/querySlice'
-import { useAppDispatch } from '@/redux/hooks'
+import { getStates } from '@/util/countries/combineStates'
 
 interface LocationProps {
-	countryFilter: Options | null
-	stateFilter: Options | null
-	dynamicStateOptions: Options[]
-	fetchDynamicFilterOptions: () => Promise<void>
+	selectedCountry: Options | null
+	selectedState: Options | null
+	setSelectedCountry: (opt: Options) => void
+	setSelectedState: (opt: Options) => void
 }
 
 const LocationForm = ({
-	countryFilter,
-	stateFilter,
-	dynamicStateOptions,
-	fetchDynamicFilterOptions,
+	selectedCountry,
+	selectedState,
+	setSelectedCountry,
+	setSelectedState,
 }: LocationProps) => {
 	const { t } = useTranslation('reviews')
-
-	const dispatch = useAppDispatch()
-
-	useEffect(() => {
-		fetchDynamicFilterOptions()
-	}, [stateFilter])
-
-	useEffect(() => {
-		dispatch(clearFilters())
-		dispatch(updateCountry(countryFilter))
-		updateActiveFilters([countryFilter])
-		fetchDynamicFilterOptions()
-	}, [countryFilter])
-
-	useEffect(() => {
-		dispatch(updateActiveFilters([stateFilter]))
-	}, [stateFilter])
 
 	return (
 		<>
@@ -52,23 +29,23 @@ const LocationForm = ({
 						{t('reviews.select_country')}
 					</h2>
 					<SelectList
-						state={countryFilter}
-						setState={(opt: Options) => dispatch(updateCountry(opt))}
+						state={selectedCountry}
+						setState={(opt: Options) => setSelectedCountry(opt)}
 						options={countryOptions}
 						name={t('reviews.country')}
 					/>
 				</div>
 				<div className='py-4'></div>
 				<div className='grid w-11/12 py-2'>
-					{!countryFilter ? null : (
+					{!selectedCountry ? null : (
 						<>
 							<h2 className='border-b text-lg font-semibold leading-10 text-gray-900 sm:text-lg md:text-xl lg:text-2xl xl:text-2xl '>
 								{t('reviews.select_state')}
 							</h2>
 							<ComboBox
-								state={stateFilter}
-								setState={(opt: Options) => dispatch(updateState(opt))}
-								options={dynamicStateOptions}
+								state={selectedState}
+								setState={(opt: Options) => setSelectedState(opt)}
+								options={getStates(selectedCountry.value)}
 								name={t('reviews.state')}
 							/>
 						</>

--- a/components/reviews/components/StateInfo.tsx
+++ b/components/reviews/components/StateInfo.tsx
@@ -7,6 +7,7 @@ import { clearFilters } from '@/redux/query/querySlice'
 import { fetchWithBody } from '@/util/helpers/fetcher'
 import { toTitleCase } from '@/util/helpers/toTitleCase'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import useSWR from 'swr'
 
 interface IProps {
@@ -16,6 +17,7 @@ interface IProps {
 }
 
 const StateInfo = ({ state, country, setLocationOpen }: IProps) => {
+	const router = useRouter()
 	const { data, error } = useSWR(
 		['/api/review/state-info', { state, country }],
 		fetchWithBody,
@@ -54,6 +56,7 @@ const StateInfo = ({ state, country, setLocationOpen }: IProps) => {
 						onClick={() => {
 							dispatch(clearFilters())
 							setLocationOpen(true)
+							router.push(`/reviews`, undefined, { shallow: true })
 						}}
 					>
 						Change Country / State
@@ -65,7 +68,7 @@ const StateInfo = ({ state, country, setLocationOpen }: IProps) => {
 					average={data.average}
 					total={data.total}
 				/>
-				<div className='flex flex-wrap w-full flex-row justify-center gap-2'>
+				<div className='flex w-full flex-row flex-wrap justify-center gap-2'>
 					{cities ? (
 						cities.map((city) => {
 							return (

--- a/components/reviews/mobile-review-filters.tsx
+++ b/components/reviews/mobile-review-filters.tsx
@@ -8,6 +8,7 @@ import ComboBox from './ui/combobox'
 import { AppDispatch } from '@/redux/store'
 import {
 	clearFilters,
+	clearReviewFilters,
 	updateCity,
 	updateCountry,
 	updateSearch,
@@ -143,7 +144,7 @@ export default function MobileReviewFilters({
 									<div className='flex w-full justify-end pt-2'>
 										<ButtonLight
 											onClick={() => {
-												dispatch(clearFilters())
+												dispatch(clearReviewFilters())
 												setMobileFiltersOpen(false)
 												updateParams()
 											}}

--- a/components/reviews/review-filters.tsx
+++ b/components/reviews/review-filters.tsx
@@ -6,6 +6,7 @@ import ComboBox from './ui/combobox'
 import { AppDispatch } from '@/redux/store'
 import {
 	clearFilters,
+	clearReviewFilters,
 	updateCity,
 	updateCountry,
 	updateSearch,
@@ -151,7 +152,7 @@ function ReviewFilters({
 						</button>
 						<ButtonLight
 							onClick={() => {
-								dispatch(clearFilters())
+								dispatch(clearReviewFilters())
 								updateParams()
 							}}
 						>

--- a/components/reviews/review-form.tsx
+++ b/components/reviews/review-form.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import React, { useState, useMemo, useEffect } from 'react'
-import { Options } from '@/util/interfaces/interfaces'
-import { debounce } from 'lodash'
+import React, { useState, useEffect } from 'react'
 import { Review as IReview } from '@/util/interfaces/interfaces'
 import Review from './review'
-import { fetchFilterOptions } from '@/util/helpers/fetchFilterOptions'
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
-import { getCityOptions, getStateOptions, getZipOptions } from './functions'
 import { useRouter } from 'next/router'
 import Hero from './components/Hero'
+import { updateStateAndCountry } from '@/redux/query/querySlice'
+import { countryOptions } from '@/util/helpers/getCountryCodes'
+import { getStates } from '@/util/countries/combineStates'
 
 export type ReviewsResponse = {
 	reviews: IReview[]
@@ -20,103 +19,65 @@ export type ReviewsResponse = {
 	limit: number
 }
 
-function ReviewForm({ data }: { data: ReviewsResponse }): JSX.Element {
+function ReviewForm(): JSX.Element {
 	const [locationOpen, setLocationOpen] = useState<boolean>(true)
-	const [loading, setLoading] = useState<boolean>(false)
 	const [isLoading, setIsLoading] = useState(false)
 
 	const router = useRouter()
-	const { view } = router.query
+	const { view, country, state } = router.query
 
-	useEffect(() => {
-		if (view && view === 'map') {
-			setLocationOpen(false)
-		}
-	}, [view])
 	// Redux
 	const query = useAppSelector((state) => state.query)
-	const { countryFilter, stateFilter, cityFilter, zipFilter, searchFilter } =
-		query
+	const { countryFilter, stateFilter } = query
 
 	const dispatch = useAppDispatch()
 
-	const handleSubmit = async () => {
-		setLoading(true)
-		setLocationOpen(false)
-	}
+	useEffect(() => {
+		if (view === 'map') {
+			setLocationOpen(false)
+			return // Exit early if the view is 'map'
+		}
+
+		if (country && state) {
+			const foundCountry = countryOptions.find(
+				(option) => option.value === decodeURIComponent(country as string),
+			)
+			const foundState = getStates(foundCountry?.value).find(
+				(option) => option.value === decodeURIComponent(state as string),
+			)
+
+			if (foundCountry && foundState) {
+				dispatch(
+					updateStateAndCountry({ country: foundCountry, state: foundState }),
+				)
+				const isLocationValid = Boolean(countryFilter && stateFilter)
+				setLocationOpen(isLocationValid)
+			}
+		}
+	}, [view, country, state])
 
 	useEffect(() => {
-		if (!countryFilter) setLoading(false)
-	}, [countryFilter])
-
-	const cityOptions = useMemo(
-		() => getCityOptions(data?.cities ?? []),
-		[data?.cities],
-	)
-	const [dynamicCityOptions, setDynamicCityOptions] =
-		useState<Options[]>(cityOptions)
-
-	const stateOptions = useMemo(
-		() => getStateOptions(data?.states ?? []),
-		[data?.states],
-	)
-	const [dynamicStateOptions, setDynamicStateOptions] =
-		useState<Options[]>(stateOptions)
-
-	const zipOptions = useMemo(
-		() => getZipOptions(data?.zips ?? []),
-		[data?.zips],
-	)
-	const [dynamicZipOptions, setDynamicZipOptions] = useState<Options[]>(
-		zipOptions ?? [],
-	)
-
-	const fetchDynamicFilterOptions = debounce(async () => {
-		setIsLoading(true)
-		try {
-			const filterOptions = await fetchFilterOptions(
-				countryFilter?.value,
-				stateFilter?.value,
-				cityFilter?.value,
-				zipFilter?.value,
+		if (countryFilter && stateFilter) {
+			setLocationOpen(false)
+			router.push(
+				`/reviews?country=${encodeURIComponent(
+					countryFilter.value,
+				)}&state=${encodeURIComponent(stateFilter.value)}`,
+				undefined,
+				{ shallow: true },
 			)
-			setDynamicCityOptions(filterOptions.cities)
-			setDynamicStateOptions(filterOptions.states)
-			setDynamicZipOptions(filterOptions.zips)
-		} catch (error) {
-			console.error('Error fetching filter options:', error)
-		} finally {
-			setIsLoading(false)
 		}
-	}, 300)
+	}, [stateFilter, countryFilter])
 
 	return !locationOpen ? (
 		<Review
-			data={data}
-			query={query}
-			searchFilter={searchFilter}
-			countryFilter={countryFilter}
-			stateFilter={stateFilter}
-			cityFilter={cityFilter}
-			zipFilter={zipFilter}
-			dynamicCityOptions={dynamicCityOptions}
-			dynamicZipOptions={dynamicZipOptions}
-			dispatch={dispatch}
-			fetchDynamicFilterOptions={fetchDynamicFilterOptions}
 			isLoading={isLoading}
 			setIsLoading={setIsLoading}
 			view={view}
 			setLocationOpen={setLocationOpen}
 		/>
 	) : (
-		<Hero
-			loading={loading}
-			countryFilter={countryFilter}
-			stateFilter={stateFilter}
-			dynamicStateOptions={dynamicStateOptions}
-			fetchDynamicFilterOptions={fetchDynamicFilterOptions}
-			handleSubmit={handleSubmit}
-		/>
+		<Hero countryFilter={countryFilter} stateFilter={stateFilter} />
 	)
 }
 

--- a/components/reviews/review-form.tsx
+++ b/components/reviews/review-form.tsx
@@ -13,7 +13,6 @@ export type ReviewsResponse = {
 	reviews: IReview[]
 	total: number
 	countries: string[]
-	states: string[]
 	cities: string[]
 	zips: string[]
 	limit: number

--- a/components/reviews/review.tsx
+++ b/components/reviews/review.tsx
@@ -27,7 +27,6 @@ export type ReviewsResponse = {
 	reviews: IReview[]
 	total: number
 	countries: string[]
-	states: string[]
 	cities: string[]
 	zips: string[]
 	limit: number

--- a/components/reviews/review.tsx
+++ b/components/reviews/review.tsx
@@ -4,7 +4,6 @@ import {
 	Review as IReview,
 	SortOptions,
 	Options,
-	IQuery,
 } from '@/util/interfaces/interfaces'
 import React, { useEffect, useState, Dispatch, SetStateAction } from 'react'
 import ReportModal from '@/components/reviews/report-modal'
@@ -19,8 +18,10 @@ import { useTranslation } from 'next-i18next'
 import ButtonLight from '../ui/button-light'
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import MapComponent from '../Map/Map'
-import { AppDispatch } from '@/redux/store'
 import StateInfo from './components/StateInfo'
+import { debounce } from 'lodash'
+import { fetchFilterOptions } from '@/util/helpers/fetchFilterOptions'
+import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 
 export type ReviewsResponse = {
 	reviews: IReview[]
@@ -53,17 +54,6 @@ export interface QueryParams {
 }
 
 interface ReviewProps {
-	data: ReviewsResponse
-	query: IQuery
-	searchFilter: string | undefined
-	countryFilter: Options | null
-	stateFilter: Options | null
-	cityFilter: Options | null
-	zipFilter: Options | null
-	dynamicCityOptions: Options[]
-	dynamicZipOptions: Options[]
-	dispatch: AppDispatch
-	fetchDynamicFilterOptions: () => Promise<void>
 	isLoading: boolean
 	setIsLoading: Dispatch<SetStateAction<boolean>>
 	view: string | string[] | undefined
@@ -71,17 +61,6 @@ interface ReviewProps {
 }
 
 const Review = ({
-	data,
-	query,
-	searchFilter,
-	countryFilter,
-	stateFilter,
-	cityFilter,
-	zipFilter,
-	dynamicCityOptions,
-	dynamicZipOptions,
-	dispatch,
-	fetchDynamicFilterOptions,
 	isLoading,
 	setIsLoading,
 	view,
@@ -90,8 +69,14 @@ const Review = ({
 	// Localization
 	const { t } = useTranslation('reviews')
 
+	// Redux
+	const query = useAppSelector((state) => state.query)
+	const { countryFilter, stateFilter, cityFilter, zipFilter, searchFilter } =
+		query
+	const dispatch = useAppDispatch()
+
 	// State
-	const [reviews, setReviews] = useState<IReview[]>(data?.reviews || [])
+	const [reviews, setReviews] = useState<IReview[]>([])
 	const [page, setPage] = useState<number>(1)
 	const [mobileFiltersOpen, setMobileFiltersOpen] = useState<boolean>(false)
 	const [selectedSort, setSelectedSort] = useState<SortOptions>(sortOptions[2])
@@ -172,6 +157,28 @@ const Review = ({
 	useEffect(() => {
 		fetchData()
 	}, [queryParams, page])
+
+	const [dynamicCityOptions, setDynamicCityOptions] = useState<Options[]>([])
+
+	const [dynamicZipOptions, setDynamicZipOptions] = useState<Options[]>([])
+
+	const fetchDynamicFilterOptions = debounce(async () => {
+		setIsLoading(true)
+		try {
+			const filterOptions = await fetchFilterOptions(
+				countryFilter?.value,
+				stateFilter?.value,
+				cityFilter?.value,
+				zipFilter?.value,
+			)
+			setDynamicCityOptions(filterOptions.cities)
+			setDynamicZipOptions(filterOptions.zips)
+		} catch (error) {
+			console.error('Error fetching filter options:', error)
+		} finally {
+			setIsLoading(false)
+		}
+	}, 300)
 
 	return (
 		<>

--- a/components/ui/StateSelector.tsx
+++ b/components/ui/StateSelector.tsx
@@ -1,12 +1,4 @@
 import { useTranslation } from 'next-i18next'
-import provinces from '@/util/countries/canada/provinces.json'
-import regions from '@/util/countries/unitedKingdom/regions.json'
-import states from '@/util/countries/unitedStates/states.json'
-import territories from '@/util/countries/australia/territories.json'
-import nz_provinces from '@/util/countries/newZealand/nz-provinces.json'
-import de_states from '@/util/countries/germany/states.json'
-import ie_counties from '@/util/countries/ireland/counties.json'
-import no_counties from '@/util/countries/norway/counties.json'
 import { Fragment } from 'react'
 import {
 	Listbox,
@@ -16,6 +8,7 @@ import {
 	Transition,
 } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/solid'
+import { getStates } from '@/util/countries/combineStates'
 
 interface IProps {
 	country: string | undefined
@@ -52,101 +45,11 @@ const StateSelector = ({ country, value, setValue, noState }: IProps) => {
 						anchor='bottom start'
 						className='mt-1 max-h-[250px] w-[250px] overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'
 					>
-						{country === 'CA'
-							? provinces.map((province) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={province.short}
-											value={province.name}
-										>
-											{province.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'GB'
-							? regions.map((region) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={region.short}
-											value={region.name}
-										>
-											{region.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'AU'
-							? territories.map((territory) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={territory.short}
-											value={territory.name}
-										>
-											{territory.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'NZ'
-							? nz_provinces.map((prov) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={prov.short}
-											value={prov.name}
-										>
-											{prov.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'DE'
-							? de_states.map((state) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={state.short}
-											value={state.name}
-										>
-											{state.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'IE'
-							? ie_counties.map((county) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={county.short}
-											value={county.name}
-										>
-											{county.name}
-										</ListboxOption>
-									)
-							  })
-							: country === 'NO'
-							? no_counties.map((county) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={county.short}
-											value={county.name}
-										>
-											{county.name}
-										</ListboxOption>
-									)
-							  })
-							: states.map((state) => {
-									return (
-										<ListboxOption
-											className='cursor-pointer p-2 hover:bg-teal-300'
-											key={state.short}
-											value={state.name}
-										>
-											{state.name}
-										</ListboxOption>
-									)
-							  })}
+						{getStates(country).map((province) => (
+							<option key={province.value} value={province.value}>
+								{province.name}
+							</option>
+						))}
 						{noState && (
 							<ListboxOption
 								className='cursor-pointer p-2 hover:bg-teal-300'

--- a/lib/review/models/review.ts
+++ b/lib/review/models/review.ts
@@ -34,7 +34,6 @@ export type ReviewsResponse = {
 	reviews: Review[]
 	total: number
 	countries: string[]
-	states: string[]
 	cities: string[]
 	zips: string[]
 	limit: number
@@ -42,12 +41,11 @@ export type ReviewsResponse = {
 
 export type FilterOptions = {
 	countries: Options[]
-	states: Options[]
 	cities: Options[]
 	zips: Options[]
 }
 
 export interface ReviewResponseStatus {
-	success: boolean,
+	success: boolean
 	message: string
 }

--- a/lib/review/review.ts
+++ b/lib/review/review.ts
@@ -3,7 +3,7 @@ import {
 	ReviewsResponse,
 	OtherLandlord,
 	FilterOptions,
-	ReviewResponseStatus
+	ReviewResponseStatus,
 } from '@/lib/review/models/review'
 import { filterReviewWithAI, IResult } from './helpers'
 import {
@@ -55,14 +55,6 @@ export async function filterOptions(
     `
 	const countryList = countries.map(({ country_code }) => country_code)
 
-	// Fetch states
-	const states = await sql`
-        SELECT DISTINCT state
-        FROM review
-        WHERE 1 = 1 ${countryClause};
-    `
-	const stateList = states.map(({ state }) => state)
-
 	// Fetch cities
 	const cities = await sql`
         SELECT DISTINCT city
@@ -70,7 +62,6 @@ export async function filterOptions(
         WHERE 1 = 1 ${countryClause} ${stateClause};
     `
 	const cityList = cities.map(({ city }) => city)
-
 
 	// Fetch zips
 	const zips = await sql`
@@ -83,30 +74,22 @@ export async function filterOptions(
 	const zipList = zipsExtracted.filter((zip) => zip.length > 0)
 
 	const filteredCity = cityList.filter((n) => n)
-	const allCityOptions = [...new Map(filteredCity.map((c, id) => {
-		const city = c.toLowerCase().trim()
-		return {
-			id: id + 1,
-			name: city.split(' ').map(capitalize).join(' '),
-			value: c.toLowerCase().trim(),
-		}
-	}).map(city => [city.value, city])).values()]
+	const allCityOptions = [
+		...new Map(
+			filteredCity
+				.map((c, id) => {
+					const city = c.toLowerCase().trim()
+					return {
+						id: id + 1,
+						name: city.split(' ').map(capitalize).join(' '),
+						value: c.toLowerCase().trim(),
+					}
+				})
+				.map((city) => [city.value, city]),
+		).values(),
+	]
 
 	allCityOptions.sort((a: Options, b: Options): number =>
-		a.name.localeCompare(b.name),
-	)
-
-
-	const allStateOptions = [...new Map(stateList.map((s, id) => {
-		const state = s.toLowerCase()
-		return {
-			id: id + 1,
-			name: state.split(' ').map(capitalize).join(' '),
-			value: s,
-		}
-	}).map(state => [state.value, state])).values()]
-
-	allStateOptions.sort((a: Options, b: Options): number =>
 		a.name.localeCompare(b.name),
 	)
 
@@ -130,7 +113,6 @@ export async function filterOptions(
 
 	return {
 		countries: countryList,
-		states: allStateOptions,
 		cities: allCityOptions,
 		zips: allZipOptions,
 	}
@@ -213,14 +195,6 @@ export async function getReviews(
     `
 	const countryList = countries.map(({ country_code }) => country_code)
 
-	// Fetch states
-	const states = await sql`
-        SELECT DISTINCT state
-        FROM review
-        WHERE 1 = 1 ${countryClause};
-    `
-	const stateList = states.map(({ state }) => state)
-
 	// Fetch cities
 	const cities = await sql`
         SELECT DISTINCT city
@@ -244,7 +218,6 @@ export async function getReviews(
 		reviews,
 		total,
 		countries: countryList,
-		states: stateList,
 		cities: cityList,
 		zips: zipList,
 		limit: limitParam,
@@ -257,7 +230,9 @@ export async function findOne(id: number): Promise<Review[]> {
       WHERE id IN (${id});`
 }
 
-export async function create(inputReview: Review): Promise<ReviewResponseStatus> {
+export async function create(
+	inputReview: Review,
+): Promise<ReviewResponseStatus> {
 	try {
 		const existingReviewsForLandlord: Review[] =
 			await getExistingReviewsForLandlord(inputReview)
@@ -271,7 +246,12 @@ export async function create(inputReview: Review): Promise<ReviewResponseStatus>
 		)
 
 		// Don't post the review to the DB if we detect spam
-		if (reviewSpamDetected || landlordSpamDetected) return {message:"This landlord is currently under spam protection please try again later", success:false} 
+		if (reviewSpamDetected || landlordSpamDetected)
+			return {
+				message:
+					'This landlord is currently under spam protection please try again later',
+				success: false,
+			}
 
 		updateRecentReviews(inputReview.landlord)
 		if (process.env.NEXT_PUBLIC_ENVIRONMENT == 'development')

--- a/pages/reviews.tsx
+++ b/pages/reviews.tsx
@@ -1,14 +1,9 @@
-import { ReviewsResponse } from '@/components/reviews/review'
 import { NextSeo } from 'next-seo'
 import React from 'react'
 import { useRouter } from 'next/router'
 import ReviewForm from '@/components/reviews/review-form'
 
-interface IProps {
-	data: ReviewsResponse
-}
-
-export default function Reviews({ data }: IProps): JSX.Element {
+export default function Reviews(): JSX.Element {
 	const title = 'Reviews | Rate The Landlord'
 	const desc =
 		'View and Search for Landlord Reviews and learn about others Rental Experience. We are a community platform that elevates tenant voices to promote landlord accountability.'
@@ -50,7 +45,7 @@ export default function Reviews({ data }: IProps): JSX.Element {
 					},
 				]}
 			/>
-			<ReviewForm data={data} />
+			<ReviewForm />
 		</>
 	)
 }

--- a/pages/reviews.tsx
+++ b/pages/reviews.tsx
@@ -2,7 +2,6 @@ import { ReviewsResponse } from '@/components/reviews/review'
 import { NextSeo } from 'next-seo'
 import React from 'react'
 import { useRouter } from 'next/router'
-import { getReviews } from '@/lib/review/review'
 import ReviewForm from '@/components/reviews/review-form'
 
 interface IProps {
@@ -54,23 +53,4 @@ export default function Reviews({ data }: IProps): JSX.Element {
 			<ReviewForm data={data} />
 		</>
 	)
-}
-
-//Page is statically generated at build time and then revalidated at a minimum of every 100 seconds based on when the page is accessed
-export async function getStaticProps() {
-	const data = await getReviews({})
-
-	if (data) {
-		return {
-			props: JSON.parse(JSON.stringify({ data: data })),
-			revalidate: 100,
-		}
-	} else {
-		return {
-			props: {
-				data: [],
-			},
-			revalidate: 100,
-		}
-	}
 }

--- a/redux/query/querySlice.ts
+++ b/redux/query/querySlice.ts
@@ -12,6 +12,11 @@ interface IQuery {
 	searchFilter: string | undefined
 }
 
+interface IStateAndCountry {
+	state: Options | null
+	country: Options | null
+}
+
 const initialState: IQuery = {
 	selectedSort: sortOptions[2],
 	countryFilter: null,
@@ -47,6 +52,17 @@ const querySlice = createSlice({
 		updateActiveFilters(state, action: PayloadAction<Array<Options | null>>) {
 			return { ...state, activeFilters: action.payload }
 		},
+		updateStateAndCountry(state, action: PayloadAction<IStateAndCountry>) {
+			state.countryFilter = action.payload.country
+			state.stateFilter = action.payload.state
+		},
+		clearReviewFilters(state) {
+			return {
+				...initialState,
+				countryFilter: state.countryFilter,
+				stateFilter: state.stateFilter,
+			}
+		},
 		clearFilters() {
 			return { ...initialState }
 		},
@@ -62,5 +78,7 @@ export const {
 	updateZip,
 	updateActiveFilters,
 	clearFilters,
+	updateStateAndCountry,
+	clearReviewFilters,
 } = querySlice.actions
 export default querySlice.reducer

--- a/util/countries/combineStates.tsx
+++ b/util/countries/combineStates.tsx
@@ -1,0 +1,79 @@
+import territories from '@/util/countries/australia/territories.json'
+import provinces from '@/util/countries/canada/provinces.json'
+import germanyStates from '@/util/countries/germany/states.json'
+import counties from '@/util/countries/ireland/counties.json'
+import nzProvinces from '@/util/countries/newZealand/nz-provinces.json'
+import regions from '@/util/countries/unitedKingdom/regions.json'
+import states from '@/util/countries/unitedStates/states.json'
+import norwayCounties from '@/util/countries/norway/counties.json'
+
+export const getStates = (country: string | undefined) => {
+	switch (country) {
+		case 'CA':
+			return provinces.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'GB':
+			return regions.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'AU':
+			return territories.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'DE':
+			return germanyStates.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'IE':
+			return counties.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'NZ':
+			return nzProvinces.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'US':
+			return states.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		case 'NO':
+			return norwayCounties.map((province, idx) => {
+				return {
+					id: idx + 1,
+					name: province.name,
+					value: province.name.toLocaleUpperCase(),
+				}
+			})
+		default:
+			return []
+	}
+}


### PR DESCRIPTION
Bigger update than I was expecting...

- A URL Query can now be passed to get straight to the reviews for a specific country and state. Hoping to expand this further in the future, but for now this works well. 
- URL is also updated with this query information when a User picks a country and state, so if they want to share the link it will open right to that same country and state.
- I removed the dynamicState functionality and replaced it with a static function that will return states based on country. This is faster and we don't really need to query the DB for states like we do cities and zips. 
- No longer use `staticProps` on the review page. Since we make the user select a country and state first, we don't need to build the page with reviews
- A ton of other refactoring. I noticed that we were passing things like `dispatch` down multiple levels which is kind of the opposite of how redux should be used. Noticed some other issues similar to this, likely just leftover from when we were building quickly. 