### PR TITLE
modifying getStaticProps to serverside render correct json files

### DIFF
--- a/components/city/CityPage.tsx
+++ b/components/city/CityPage.tsx
@@ -26,7 +26,7 @@ interface IProps {
 
 const CityPage = ({ city, state, country, data }: IProps) => {
 	// Localization
-	const { t } = useTranslation('landlord')
+	const { t } = useTranslation('reviews')
 
 	// Redux
 	const query = useAppSelector((state) => state.query)

--- a/components/create-review/SheldonModal.tsx
+++ b/components/create-review/SheldonModal.tsx
@@ -9,7 +9,7 @@ interface IProps {
 }
 
 function SheldonModal({ isOpen, setIsOpen }: IProps) {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<Transition.Root show={isOpen} as={Fragment}>
 			<Dialog as='div' className='relative z-10' onClose={setIsOpen}>

--- a/components/create-review/SpamReviewModal.test.tsx
+++ b/components/create-review/SpamReviewModal.test.tsx
@@ -8,18 +8,16 @@ import SpamReviewModal from '@/components/create-review/SpamReviewModal'
 jest.mock('react-i18next', () => ({
 	useTranslation: jest.fn().mockReturnValue({
 		t: jest.fn((key) => {
-			if (key === 'create-review.spam-modal.localStorageDetection.title') {
+			if (key === 'create-review.localStorageDetection.title') {
 				return 'It appears you have reviewed this Landlord before...'
 			}
-			if (
-				key === 'create-review.spam-modal.localStorageDetection.description'
-			) {
-				return "We understand you want to voice your frustration about your previous Landlord in a safe and public way. However, leaving multiple reviews about the same landlord causes both the reviews for that Landlord, and the site, to lose their integrity. Please only leave 1 review per landlord you've had so that this site can remain a fair representation for both the Tenants and Landlords."
+			if (key === 'create-review.localStorageDetection.description') {
+				return "Please only leave one review per landlord you've had so that this site can remain a fair representation of rental experiences. Any repeat reviews or spam will be deleted. If you have any questions, please reach out to us at contact@ratethelandlord.org"
 			}
-			if (key === 'create-review.spam-modal.DBDetection.title') {
+			if (key === 'create-review.DBDetection.title') {
 				return 'We have noticed potential spam reviews related to this landlord.'
 			}
-			if (key === 'create-review.spam-modal.DBDetection.description') {
+			if (key === 'create-review.DBDetection.description') {
 				return 'To protect the integrity of our reviews please try again later. If you have any questions, please reach out to us at contact@ratethelandlord.org'
 			}
 			if (key === 'create-review.modal.close') {
@@ -52,7 +50,7 @@ describe('Spam Review Modal component', () => {
 		).toBeInTheDocument()
 		expect(
 			screen.getByText(
-				"We understand you want to voice your frustration about your previous Landlord in a safe and public way. However, leaving multiple reviews about the same landlord causes both the reviews for that Landlord, and the site, to lose their integrity. Please only leave 1 review per landlord you've had so that this site can remain a fair representation for both the Tenants and Landlords.",
+				"Please only leave one review per landlord you've had so that this site can remain a fair representation of rental experiences. Any repeat reviews or spam will be deleted. If you have any questions, please reach out to us at contact@ratethelandlord.org",
 			),
 		).toBeInTheDocument()
 

--- a/components/create-review/SpamReviewModal.tsx
+++ b/components/create-review/SpamReviewModal.tsx
@@ -48,9 +48,7 @@ function SpamReviewModal({ isOpen, setIsOpen, detectionMethod }: IProps) {
 										</Dialog.Title>
 										<div className='mt-2'>
 											<p className='text-sm text-gray-500'>
-												{t(
-													`create-review.${detectionMethod}.description`,
-												)}
+												{t(`create-review.${detectionMethod}.description`)}
 											</p>
 										</div>
 									</div>

--- a/components/create-review/SpamReviewModal.tsx
+++ b/components/create-review/SpamReviewModal.tsx
@@ -10,7 +10,7 @@ interface IProps {
 }
 
 function SpamReviewModal({ isOpen, setIsOpen, detectionMethod }: IProps) {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<Transition.Root show={isOpen} as={Fragment}>
 			<Dialog as='div' className='relative z-10' onClose={setIsOpen}>
@@ -44,12 +44,12 @@ function SpamReviewModal({ isOpen, setIsOpen, detectionMethod }: IProps) {
 											as='h3'
 											className='text-base  leading-6 text-gray-900'
 										>
-											{t(`create-review.spam-modal.${detectionMethod}.title`)}
+											{t(`create-review.${detectionMethod}.title`)}
 										</Dialog.Title>
 										<div className='mt-2'>
 											<p className='text-sm text-gray-500'>
 												{t(
-													`create-review.spam-modal.${detectionMethod}.description`,
+													`create-review.${detectionMethod}.description`,
 												)}
 											</p>
 										</div>

--- a/components/create-review/add-review-modal.tsx
+++ b/components/create-review/add-review-modal.tsx
@@ -9,7 +9,7 @@ interface IProps {
 }
 
 function AddReviewModal({ isOpen, setIsOpen }: IProps) {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<Transition.Root show={isOpen} as={Fragment}>
 			<Dialog as='div' className='relative z-10' onClose={setIsOpen}>

--- a/components/create-review/components/LandlordForm.tsx
+++ b/components/create-review/components/LandlordForm.tsx
@@ -24,7 +24,7 @@ const LandlordForm = ({
 	landlordValidationError,
 	landlordValidationText,
 }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 
 	const {
 		isSearching,

--- a/components/create-review/components/LocationForm.tsx
+++ b/components/create-review/components/LocationForm.tsx
@@ -49,7 +49,7 @@ const LocationForm = ({
 	setRatingsOpen,
 	setShowRatingForm,
 }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return !locationOpen ? (
 		<div className='flex w-full flex-row items-center justify-between transition-all duration-500'>
 			<div className='flex flex-col gap-2'>

--- a/components/create-review/components/RatingForm.tsx
+++ b/components/create-review/components/RatingForm.tsx
@@ -41,7 +41,7 @@ const RatingForm = ({
 	setShowReviewForm,
 	setReviewOpen,
 }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return !ratingsOpen ? (
 		<div className='flex w-full flex-row items-center justify-between transition-all duration-500'>
 			<div className='flex flex-col gap-2'>

--- a/components/create-review/components/ReviewHero.tsx
+++ b/components/create-review/components/ReviewHero.tsx
@@ -10,7 +10,7 @@ interface IProps {
 }
 
 const ReviewHero = ({ getStarted, setGetStarted, setLandlordOpen }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<div
 			className={classNames(

--- a/components/create-review/components/WrittenReviewForm.tsx
+++ b/components/create-review/components/WrittenReviewForm.tsx
@@ -17,7 +17,7 @@ const WrittenReviewForm = ({
 	handleTextChange,
 	setShowPreview,
 }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return !reviewOpen ? (
 		<div className='flex w-full flex-row items-center justify-between transition-all duration-500'>
 			<div className='flex flex-col gap-2'>

--- a/components/create-review/ratings-radio.tsx
+++ b/components/create-review/ratings-radio.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 function RatingsRadio({ title, rating, setRating, tooltip }: Props) {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 
 	return (
 		<div data-testid='ratings-radio-1'>

--- a/components/create-review/review-form.tsx
+++ b/components/create-review/review-form.tsx
@@ -27,7 +27,7 @@ import WrittenReviewForm from './components/WrittenReviewForm'
 import { toast } from 'react-toastify'
 
 function ReviewForm(): JSX.Element {
-	const { t } = useTranslation(['create', 'alerts'])
+	const { t } = useTranslation(['createreview', 'alerts'])
 
 	const [getStarted, setGetStarted] = useState(false)
 	const [landlordOpen, setLandlordOpen] = useState(false)

--- a/components/create-review/success-modal.tsx
+++ b/components/create-review/success-modal.tsx
@@ -30,7 +30,7 @@ interface IProps {
 }
 
 function SuccessModal({ isOpen, setIsOpen }: IProps) {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	const router = useRouter()
 	return (
 		<Transition.Root show={isOpen} as={Fragment}>

--- a/components/resources/InfiniteScrollResources.tsx
+++ b/components/resources/InfiniteScrollResources.tsx
@@ -19,7 +19,7 @@ function InfiniteScroll({
 	isLoading,
 	setIsLoading,
 }: IProps) {
-	const { t } = useTranslation('resourcesPage')
+	const { t } = useTranslation('resources')
 	const [content, setContent] = useState<Resource[]>([]) // Store loaded content: ;
 	// Add a scroll event listener
 	useEffect(() => {

--- a/components/resources/resourcesInfo.tsx
+++ b/components/resources/resourcesInfo.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next'
 
 const ResourcesInfo = () => {
-	const { t } = useTranslation('resourcesPage')
+	const { t } = useTranslation('resources')
 	const info: Array<string> = t('resources.info', {
 		returnObjects: true,
 	})

--- a/components/ui/CountrySelector.tsx
+++ b/components/ui/CountrySelector.tsx
@@ -7,7 +7,7 @@ interface IProps {
 }
 
 const CountrySelector = ({ setValue }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<div className='sm:col-span-1'>
 			<label htmlFor='country' className='block text-sm  text-gray-700'>

--- a/components/ui/StateSelector.tsx
+++ b/components/ui/StateSelector.tsx
@@ -18,7 +18,7 @@ interface IProps {
 }
 
 const StateSelector = ({ country, value, setValue, noState }: IProps) => {
-	const { t } = useTranslation('create')
+	const { t } = useTranslation('createreview')
 	return (
 		<div data-testid='state-selector' className='sm:col-span-1'>
 			<Listbox value={value} onChange={setValue}>

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -6,6 +6,7 @@
 module.exports = {
 	// https://www.i18next.com/overview/configuration-options#logging
 	debug: process.env.NODE_ENV === 'development',
+	defaultNS: 'home',
 	i18n: {
 		defaultLocale: 'en-CA',
 		locales: ['en-CA', 'fr-CA'],

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router'
 import React from 'react'
 import Revenue from '@/components/about/revenue'
 import Poster from '@/components/poster/Poster'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 function About(): JSX.Element {
 	const title = 'About | Rate The Landlord'
@@ -68,3 +69,15 @@ function About(): JSX.Element {
 }
 
 export default About
+
+export async function getStaticProps({ locale }) {
+  return {
+	props: {
+	  ...(await serverSideTranslations(locale, [
+		'about',
+		'layout'
+	  ])),
+	  // Will be passed to the page component as props
+	},
+  }
+}

--- a/pages/admin/[admin].tsx
+++ b/pages/admin/[admin].tsx
@@ -177,3 +177,4 @@ function Admin(): JSX.Element {
 }
 
 export default withPageAuthRequired(Admin)
+

--- a/pages/admin/[admin].tsx
+++ b/pages/admin/[admin].tsx
@@ -177,4 +177,3 @@ function Admin(): JSX.Element {
 }
 
 export default withPageAuthRequired(Admin)
-

--- a/pages/cities/[country_code]/[state]/[city].tsx
+++ b/pages/cities/[country_code]/[state]/[city].tsx
@@ -4,6 +4,7 @@ import { ICityReviews, getCityReviews } from '@/lib/review/review'
 import { toTitleCase } from '@/util/helpers/toTitleCase'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 interface IProps {
 	city: string
@@ -78,7 +79,8 @@ export async function getStaticPaths() {
 	}
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ locale, params }) {
+	console.log(params)
 	const data = await getCityReviews(params)
 
 	if (data.reviews.length === 0) {
@@ -92,14 +94,19 @@ export async function getStaticProps({ params }) {
 
 	// Pass post data to the page via props
 	return {
-		props: JSON.parse(
-			JSON.stringify({
+		props: JSON.parse(JSON.stringify({
 				city: params.city,
 				state: params.state,
 				country: params.country_code,
 				data: data,
-			}),
-		),
+				...(await serverSideTranslations(locale, [
+					'filters',
+					'resources',
+					'layout',
+					'landlord',
+					'reviews'
+				  ])),
+			})),
 		// Re-generate the page
 		// if a request comes in after 100 seconds
 		revalidate: 100,

--- a/pages/create-review.tsx
+++ b/pages/create-review.tsx
@@ -2,6 +2,7 @@ import ReviewForm from '@/components/create-review/review-form'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import React from 'react'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 function CreateReview(): JSX.Element {
 	const title = 'Create Review | Rate The Landlord'
@@ -56,3 +57,16 @@ function CreateReview(): JSX.Element {
 }
 
 export default CreateReview
+
+export async function getStaticProps({ locale }) {
+	return {
+	  props: {
+		...(await serverSideTranslations(locale, [
+		  'createreview',
+		  'layout',
+		  'reviews'
+		])),
+		// Will be passed to the page component as props
+	  },
+	}
+  }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import Testimonials from '@/components/home/testimonials'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import React from 'react'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 export default function Home(): JSX.Element {
 	const title = 'Rate The Landlord'
@@ -57,4 +58,22 @@ export default function Home(): JSX.Element {
 			<Testimonials />
 		</div>
 	)
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, [
+		'about',
+		'alerts',
+		'createreview',
+		'filters',
+		'home',
+		'layout',
+		'landlord',
+		'reviews'
+      ])),
+      // Will be passed to the page component as props
+    },
+  }
 }

--- a/pages/landlord/[landlord].tsx
+++ b/pages/landlord/[landlord].tsx
@@ -3,6 +3,7 @@ import Spinner from '@/components/ui/Spinner'
 import { ILandlordReviews, getLandlordReviews } from '@/lib/review/review'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 interface IProps {
 	landlord: string
@@ -69,7 +70,7 @@ export async function getStaticPaths() {
 	}
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ locale, params }) {
 	const data = await getLandlordReviews(params.landlord)
 
 	if (!data || data.reviews.length === 0) {
@@ -84,7 +85,14 @@ export async function getStaticProps({ params }) {
 	// Pass post data to the page via props
 	return {
 		props: JSON.parse(
-			JSON.stringify({ landlord: params.landlord, data: data }),
+			JSON.stringify({ landlord: params.landlord, data: data,
+				...(await serverSideTranslations(locale, [
+					'filters',
+					'layout',
+					'landlord',
+					'reviews'
+				  ])),
+			 }),
 		),
 		// Re-generate the page
 		// if a request comes in after 100 seconds

--- a/pages/landlord/[landlord].tsx
+++ b/pages/landlord/[landlord].tsx
@@ -85,14 +85,16 @@ export async function getStaticProps({ locale, params }) {
 	// Pass post data to the page via props
 	return {
 		props: JSON.parse(
-			JSON.stringify({ landlord: params.landlord, data: data,
+			JSON.stringify({
+				landlord: params.landlord,
+				data: data,
 				...(await serverSideTranslations(locale, [
 					'filters',
 					'layout',
 					'landlord',
-					'reviews'
-				  ])),
-			 }),
+					'reviews',
+				])),
+			}),
 		),
 		// Re-generate the page
 		// if a request comes in after 100 seconds

--- a/pages/resources.tsx
+++ b/pages/resources.tsx
@@ -7,6 +7,7 @@ import { ResourceResponse } from '@/util/interfaces/interfaces'
 import { getResources } from '@/lib/tenant-resource/resource'
 import { useTranslation } from 'next-i18next'
 import Poster from '@/components/poster/Poster'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 interface IProps {
 	data: ResourceResponse
@@ -22,7 +23,7 @@ function Resources({ data }: IProps): JSX.Element {
 	const pageURL = pathName === '/' ? siteURL : siteURL + pathName
 	const twitterHandle = '@r8thelandlord'
 	const siteName = 'RateTheLandlord.org'
-	const { t } = useTranslation('resourcesPage')
+	const { t } = useTranslation('resources')
 	return (
 		<div className='flex w-full justify-center'>
 			<NextSeo
@@ -66,16 +67,27 @@ function Resources({ data }: IProps): JSX.Element {
 export default Resources
 
 //Page is statically generated at build time and then revalidated at a minimum of every 30 minutes based on when the page is accessed
-export async function getStaticProps() {
+export async function getStaticProps({ locale }) {
 	const data = await getResources({})
 	if (data) {
 		return {
-			props: JSON.parse(JSON.stringify({ data: data })),
-			revalidate: 100,
+			props:JSON.parse(JSON.stringify({ data: data,
+				...(await serverSideTranslations(locale, [
+					'filters',
+					'resources',
+					'layout'
+				  ])),
+			 }))
+			,
+			revalidate: 100,			
 		}
 	} else {
 		return {
 			props: {
+				...(await serverSideTranslations(locale, [
+					'resources',
+					'layout'
+				  ])),
 				data: [],
 			},
 			revalidate: 100,

--- a/pages/reviews.tsx
+++ b/pages/reviews.tsx
@@ -2,6 +2,7 @@ import { NextSeo } from 'next-seo'
 import React from 'react'
 import { useRouter } from 'next/router'
 import ReviewForm from '@/components/reviews/review-form'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 export default function Reviews(): JSX.Element {
 	const title = 'Reviews | Rate The Landlord'
@@ -48,4 +49,18 @@ export default function Reviews(): JSX.Element {
 			<ReviewForm />
 		</>
 	)
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+	props: {
+	  ...(await serverSideTranslations(locale, [
+		'reviews',
+		'filters',
+		'landlord',
+		'layout'
+	  ])),
+	  // Will be passed to the page component as props
+	},
+  }
 }

--- a/pages/support-us.tsx
+++ b/pages/support-us.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import React from 'react'
 import { getMemberData, getTierData } from '@/util/helpers/patreon'
 import Supporters from '@/components/supportus/Supporters'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 export default function SupportUs({ members }): JSX.Element {
 	const title = 'Support Us | Rate The Landlord'
@@ -58,7 +59,7 @@ export default function SupportUs({ members }): JSX.Element {
 }
 
 //Page is statically generated at build time and then revalidated at a minimum of every day based on when the page is accessed
-export async function getStaticProps() {
+export async function getStaticProps({ locale }) {
 	const accessToken = process.env.PATREON_ACCESS_TOKEN as string
 
 	const campaignId = await fetch(
@@ -97,6 +98,10 @@ export async function getStaticProps() {
 
 	return {
 		props: {
+			...(await serverSideTranslations(locale, [
+				'supports',
+				'layout'
+			])),
 			members: members,
 		},
 		revalidate: 86400,

--- a/pages/support-us.tsx
+++ b/pages/support-us.tsx
@@ -98,10 +98,7 @@ export async function getStaticProps({ locale }) {
 
 	return {
 		props: {
-			...(await serverSideTranslations(locale, [
-				'supports',
-				'layout'
-			])),
+			...(await serverSideTranslations(locale, ['support', 'layout'])),
 			members: members,
 		},
 		revalidate: 86400,

--- a/pages/zips/[country_code]/[state]/[zip].tsx
+++ b/pages/zips/[country_code]/[state]/[zip].tsx
@@ -4,6 +4,7 @@ import { IZipReviews, getZipReviews } from '@/lib/review/review'
 import { toTitleCase } from '@/util/helpers/toTitleCase'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 interface IProps {
 	city: string
@@ -85,7 +86,7 @@ export async function getStaticPaths() {
 	}
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ locale, params }) {
 	const data = await getZipReviews(params)
 
 	if (data.reviews.length === 0) {
@@ -106,6 +107,13 @@ export async function getStaticProps({ params }) {
 				country: params.country_code,
 				data: data,
 				zip: params.zip,
+				...(await serverSideTranslations(locale, [
+						'filters',
+						'resources',
+						'layout',
+						'landlord',
+						'reviews'
+						])),
 			}),
 		),
 		// Re-generate the page


### PR DESCRIPTION
I think this should be fixed now unless I missed something (the support us page is throwing an error for me but I think that's because I don't have the Patreon credentials). 

The main issue seemed to be we weren't rendering server side the correct .json files in getStaticProps. There were also some incorrect references that I fixed. Finally, I set a DefaultNS in the next-i18next.config per documentation requirements (otherwise it looks for a common.js translation file and throws an error if it can't find it).  Overall, it seems to be working correctly now, and the next-i18n debugger runs in development env which is nice. 

It would be good to have a second set of eyes go into each page, change the language to French, then refresh and make sure there are no hydration errors or no errors that a translation is missing. If there is a hydration error then there is likely a .json reference missing in getStaticProps and if it says a translation is missing the t('{enter translation file here'}) was probably mistyped. 
