### PR TITLE
Adjust median rent chart data query to require review minimum

### DIFF
--- a/components/analytics/analytics.tsx
+++ b/components/analytics/analytics.tsx
@@ -114,6 +114,7 @@ const AnalyticsComponent = ({ queryParams }: AnalyticProps) => {
 				setDataKey('trailing_median_rent')
 				setYAxisLabel(t('analytics.median-rent'))
 				setChartLabel(t('analytics.median-reported'))
+				console.log(chartData.medianChartData)
 				if (chartData?.medianChartData) {
 					setMaxY(
 						Math.max(

--- a/components/analytics/analytics.tsx
+++ b/components/analytics/analytics.tsx
@@ -114,7 +114,6 @@ const AnalyticsComponent = ({ queryParams }: AnalyticProps) => {
 				setDataKey('trailing_median_rent')
 				setYAxisLabel(t('analytics.median-rent'))
 				setChartLabel(t('analytics.median-reported'))
-				console.log(chartData.medianChartData)
 				if (chartData?.medianChartData) {
 					setMaxY(
 						Math.max(

--- a/lib/analytics/review.ts
+++ b/lib/analytics/review.ts
@@ -178,7 +178,12 @@ export async function getChartData(
 			)
 			SELECT
 				TO_CHAR(ds.review_date, 'Mon, DD YYYY') AS review_date,
-				percentile_cont(0.5) WITHIN GROUP (ORDER BY r.rent) AS metric
+				CASE
+					WHEN COUNT(r.rent) >= 3 THEN
+						percentile_cont(0.5) WITHIN GROUP (ORDER BY r.rent)
+					ELSE
+						NULL
+				END AS metric
 			FROM
 				date_series ds
 			LEFT JOIN


### PR DESCRIPTION
I ended up going with 3 reviews that include rent. 10 was returning an entirely empty chart for Chicago. We can easily adjust for production data. 